### PR TITLE
Issue 14: Markdown Support for HTML Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ This is a Simple CLI tool based on nodejs for generating html files from our tex
 * Display command instructions (help):
 
   ``` reza-ssg --help```
-* Create an html file from a text file:
+* Create an html file from a text or markdown file:
 
   ``` reza-ssg --index "Silver Blaze".txt ```
 
-* Create html files from all the text files inside the 'text files' folder:
+* Create html files from all the text or markdown files inside the 'text files' folder:
 
   ``` reza-ssg --index "text files" ```
 

--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ if(options.index){
           para
             .replace(/^# (.*$)/gim, '<h1>$1</h1>')
             .replace(/^## (.*$)/gim, '<h2>$1</h2>')
-            .replace(/^--- (.*$)/gim, '<br/>')
+            .replace(/^--- (.*$)/gim, '<hr/>')
         )
         .join('\n');
     

--- a/index.js
+++ b/index.js
@@ -176,6 +176,45 @@ if(options.index){
   
   
       })
+    } else if (path.extname(file) == ".md"){
+      console.log("md file inputted!")
+      const folderName = 'dir';
+  
+      const htmlFile = fs.readFileSync(`${__dirname}/index.html`)
+  
+      filenameWithoutExt = path.parse(file).name; // The name part of the file (EX: name.txt => name)
+  
+      fs.writeFileSync(`${process.cwd()}/${folderName}/${filenameWithoutExt}.html` , htmlFile);  
+      
+      fs.readFile(file , {encoding:'utf8', flag:'r'},
+      function(err, data) {
+        if(err)
+        console.log(err);
+       
+
+        var editedText = data.split(/\r?\n\r?\n/)
+        .map((para) =>
+          para
+            .replace(/^# (.*$)/gim, '<h1>$1</h1>')
+            .replace(/^## (.*$)/gim, '<h2>$1</h2>')
+            .replace(/^--- (.*$)/gim, '<br/>')
+        )
+        .join('\n');
+    
+        let title = editedText.split("</p>")[0].split(">" , 2)[1]; // getting the title of the text
+
+        titleInsidePTag = `<h1 style="text-align: center; background-color: black; color: white; width: 50%; height: 100%; border-radius: 10px; margin: auto; top: 15px; ">${title}</h1>`
+        
+        // Appending the title
+        fs.appendFile(`${process.cwd()}/${folderName}/${path.parse(file).name}.html` , titleInsidePTag , function(err){
+          if(err) throw err;
+        })
+
+        // Appending the rest of the text
+        fs.appendFile(`${process.cwd()}/${folderName}/${path.parse(file).name}.html` , editedText.replace(title , "") , function(err){
+          if(err) throw err;
+        })
+      })     
     }
   })
 


### PR DESCRIPTION
### Linked Issue
Closes #14 

## Purpose
This PR aims to add additional feature to support markdown file conversion to HTML. 

## Method
As there was already support for txt files through conditional checks for extensions name ".txt", I added another conditional check for ",md" files. 

## Features
If the file extension is ".md", we now convert the data in the file into HTML page. The feature supports handling of:
```Header 1 support to <h1>```
```Header 2 support to <h2>```
```Horizontal Rule support to <hr/>```

## Testing
1. Checkout this branch by using ```git checkout issue-14-markdown-inputs```
2. Use ```git pull``` to ensure latest working copy of the branch is acquired.
3. Run ```npm i``` to install any missing dependencies.
4. Re-link the application by either running ```npm unlink``` or ```npm link --f```
5.  Create a markdown file. Copy one of the instructions for lab 2 into an editor and save as .md
6. Drag the file into the "text files" directory, and the StaticSiteGenerator directory. (This is an issue, I believe requires file in both)
7. Use the same command as for text files: ``` reza-ssg --index text\ files/```
8. Investigate the dir directory, where you will see the HTML file for the md file. 